### PR TITLE
KAS-3664: Predicate migrations

### DIFF
--- a/queries/documenten_bekrachtiging_niet_publiek.sparql
+++ b/queries/documenten_bekrachtiging_niet_publiek.sparql
@@ -16,7 +16,7 @@ SELECT DISTINCT ?agendapunt ?agendaPuntTitel ?meeting ?agenda ?document ?title ?
     ?agendapunt besluitvorming:geagendeerdStuk ?document .
     ?document dct:title ?title .
   }
-  ?document ext:toegangsniveauVoorDocumentVersie ?toegangsniveau .
+  ?document besluitvorming:vertrouwelijkheidsniveau ?toegangsniveau .
   ?toegangsniveau skos:prefLabel ?toegangsniveauLabel .
   FILTER ( regex(?agendaPuntTitel, "bekrachtiging", "i") )
   FILTER ( ?toegangsniveauLabel = "Intern Overheid"@nl || ?toegangsniveauLabel = "Intern Regering"@nl )

--- a/queries/dossiers_goedkeuring.sparql
+++ b/queries/dossiers_goedkeuring.sparql
@@ -29,6 +29,6 @@ SELECT DISTINCT ?dossier ?title ?shortTitle ?procedurestap ?agendapunt ?agendaPu
     }
     ?dossier dossier:doorloopt ?procedurestap .
     ?behandelingVanAgendaPunt ext:beslissingVindtPlaatsTijdens ?procedurestap .
-    ?behandelingVanAgendaPunt besluitvorming:heeftOnderwerp ?agendapunt .
+    ?behandelingVanAgendaPunt dct:subject ?agendapunt .
     ?agendapunt dct:title ?agendaPuntTitel .
 }


### PR DESCRIPTION
Replaces two predicates:
- `ext:toegangsniveauVoorDocumentVersie` → `besluitvorming:vertrouwelijkheidsniveau`
- `besluitvorming:heeftOnderwerp` → `dct:subject`
